### PR TITLE
Add references to this GH project on all documents

### DIFF
--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -5,7 +5,6 @@
 <html lang="en">
   <head>
     <meta content="text/html; charset=UTF-8" http-equiv="content-type">
-    <!-- Changed by: $Id: styleguide.html,v 1.2 2018/02/19 12:06:25 coralie Exp $ -->
     <title>W3C Styleguide &amp; Brand Guidelines</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base">
@@ -315,7 +314,6 @@
     <hr>
     <div id="footer">
       <address> <a href="mailto:yourmail@w3.org">%%your_name%%</a>, W3C </address>
-      <div id="cvsversion"></div>
     </div>
   </body>
 </html>

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+
+<!-- W3C Design — see https://github.com/w3c/design -->
+
 <html lang="en">
   <head>
     <meta content="text/html; charset=UTF-8" http-equiv="content-type">
@@ -83,9 +86,14 @@
       </ol>
     </nav>
     <p>Status: * Work in Progress * Team-only * Last updated : Feb, 2018 *</p>
-    <div id="cvsversion">
-      <pre><!-- keep -->$Id: styleguide.html,v 1.2 2018/02/19 12:06:25 coralie Exp $<!--/keep--></pre>
-    </div>
+    <div id="cvsversion"></div>
+    <section>
+      <p>
+        <strong>We are on GitHub</strong>:
+        fork this document, or file issues on
+        <a href="https://github.com/w3c/design"><code>https://github.com/w3c/design</code></a>.
+      </p>
+    </section>
     <!-- Section 1: Design Elements -->
     <section id="brand">
         <h2><span class="secno">1. </span>Graphical Elements of the W3C Brand</h2>
@@ -307,9 +315,7 @@
     <hr>
     <div id="footer">
       <address> <a href="mailto:yourmail@w3.org">%%your_name%%</a>, W3C </address>
-      <div id="cvsversion">
-	<pre><!-- keep -->$Id: styleguide.html,v 1.2 2018/02/19 12:06:25 coralie Exp $<!--/keep--></pre>
-      </div>
+      <div id="cvsversion"></div>
     </div>
   </body>
 </html>

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,7 +2,7 @@
 
 See the [generic template](https://w3c.github.io/design/templates/generic/) (no content, only boilerplate and placeholders).
 
-See an example of [an existing page adopting the template](https://w3c.github.io/design/templates/generic/guide.html).
+See an example of [an existing page adopting the template](https://w3c.github.io/design/templates/guide.html).
 
 Want to learn how to adopt these templates?
 Find detailed instructions in the [howto](howto.md).

--- a/wg-homepage/index.html
+++ b/wg-homepage/index.html
@@ -1,5 +1,9 @@
 <!DOCTYPE html>
 
+<!-- W3C Design — see https://github.com/w3c/design to learn how to use this template -->
+
+<!-- Reminder: replace all @@PLACEHOLDERS@@ and remove this line when you're done -->
+
 <html lang="en" data-apiary-key="@@api-key@@" data-apiary-group="@@group-id@@">
 <head>
 <meta charset="utf-8">
@@ -72,6 +76,7 @@ lists</a>.</p>
 href="https://www.w3.org/Consortium/Legal/privacy-statement">Privacy</a> - <a
 href='http://www.w3.org/Consortium/Legal/ipr-notice'>Terms</a>
 </p>
+<p>W3C Design — <a href="https://github.com/w3c/design">learn how to use this template, or fork it</a></p>
 </address>
 </footer>
 

--- a/wg-homepage/main.css
+++ b/wg-homepage/main.css
@@ -26,7 +26,7 @@ a, a:visited, a:hover, a:focus {
   color: #4184F3;
   background: transparent;
 }
-a, a:visited {
+:not(footer) a, :not(footer)a:visited {
   text-decoration: none;
 }
 a:hover, a:focus {
@@ -141,7 +141,10 @@ footer {
 footer p { margin: 0; padding: 0;}
 footer a, footer a:visited, footer a:focus, footer a:hover {
   color: white;
-  font-weight: bold;
+}
+
+footer a:focus, footer a:hover {
+  color: white;
 }
 
 @media screen and (min-width: 78rem) {


### PR DESCRIPTION
All four main documents (generic template, &ldquo;The Art of Consensus&rdquo; example, WG home page template, and new style guide) now include links to this project, in their source code and/or in plain sight (whatever makes sense in each case).
This fixes #13.

Also:
* Fix the link to &ldquo;The Art of Consensus&rdquo; example in README
* Tweak CSS styles of WG home page template to improve appearance of links in footer
* Remove contents of a couple `<div id="cvsversion">` in style guide (CVS legacy)