### PR TITLE
Better link text contrast ratio

### DIFF
--- a/wg-homepage/main.css
+++ b/wg-homepage/main.css
@@ -23,7 +23,7 @@ ul, ul li {
 }
 
 a, a:visited, a:hover, a:focus {
-  color: #4184F3;
+  color: #0000cc;
   background: transparent;
 }
 :not(footer) a, :not(footer)a:visited {


### PR DESCRIPTION
The link text has contrast ratio of 3.6:1 (#4184F3 on #FFF). For WCAG Level AAA, contrast should be at least 7:1.

Ref: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast7.html